### PR TITLE
Fix rackup load path

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
+$LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/lib')
 
 ENV['BEANSTALK_URL'] ||= 'beanstalk://localhost/'
 #ENV['BEANSTALK_URL'] ||= 'beanstalk://localhost:11300,beanstalk://localhost:11400'


### PR DESCRIPTION
The lib directory is at the same level as the config.ru file, not in the parent.
