### PR TITLE
Fix setting range in peak_range caused Internal Server Error

### DIFF
--- a/lib/beanstalkd_view/server.rb
+++ b/lib/beanstalkd_view/server.rb
@@ -99,8 +99,8 @@ module BeanstalkdView
           guess_tubes << @tube
         end
         # Guess ID Range if not specified
-        min = guess_min_peek_range(guess_tubes) if @min == 0
-        max = guess_max_peek_range(min) if @max == 0
+        min = @min == 0 ? guess_min_peek_range(guess_tubes) : @min
+        max = @max == 0 ? guess_max_peek_range(min) : @max
 
         @jobs = []
         for i in min..max


### PR DESCRIPTION
Trying to peek with specified range always caused Internal Server Error.
That's because of this lines:
https://github.com/denniskuczynski/beanstalkd_view/blob/master/lib/beanstalkd_view/server.rb#L102-L103
min and max were always nil unless 0
