### PR TITLE
Use 127.0.0.1 as the default host instead of localhost

### DIFF
--- a/lib/beanstalkd_view/beanstalkd_utils.rb
+++ b/lib/beanstalkd_view/beanstalkd_utils.rb
@@ -12,7 +12,7 @@ module BeanstalkdView
 
     def beanstalk_url
       return @@url if defined?(@@url) and @@url
-      ENV['BEANSTALK_URL'] || 'beanstalk://localhost/'
+      ENV['BEANSTALK_URL'] || 'beanstalk://127.0.0.1/'
     end
 
     def beanstalk_addresses


### PR DESCRIPTION
This should be used to avoid connection refused exceptions when trying
to connect to IPv6 socket (since there is no code to handle ipv4
fallback).