### PR TITLE
Customize URL base when running standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,23 @@ Running from the command line
 
 Run the beanstalkd_view executable, e.g.
 
+```bash
 beanstalkd_view
+```
 
 or from a Rails app:
 
+```bash
 bundle exec beanstalkd_view
+```
 
 (This will use the vegas gem to launch the Sinatra app on an available port.)
 
-Alternatively, a Rackup file is provided.  To use: cd into the beanstalkd_view directory and execute:
+Alternatively, a Rackup file is provided. To use go to the beanstalkd_view directory and execute:
 
+```
 rackup
+```
 
 Running with Docker
 ------------------------
@@ -115,12 +121,15 @@ There are 3 variants of RSpec tests.
 
 Customization
 ------------------------
-beanstalk_view provides a way to customize your views.
+beanstalkd_view provides a way to customize your views.
+
 Set environment variable with desired views path:
+
 ```ruby
 ENV['BEANSTALKD_VIEW_TEMPLATES'] = File.join("my", "app", "views", "beanstalkd")
 ```
-The just copy lib/beanstalkd_view/views/*.erb and customize them as you want.
+
+Then just copy `lib/beanstalkd_view/views/*.erb` and customize them as you want.
 
 *Note: the environment variable should be set before gem loads.*
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ Alternatively, a Rackup file is provided. To use go to the beanstalkd_view direc
 rackup
 ```
 
+If you run beanstalkd_view from the command line you can specify the URL base path.
+
+Set environment variable with the base URL (don't forget the leading slash '/''):
+
+```ruby
+ENV['BEANSTALKD_VIEW_PATH'] = '/path'
+```
+
+or
+
+```bash
+export BEANSTALKD_VIEW_PATH = '/path'
+```
+
+Setting `BEANSTALKD_VIEW_PATH` applies to both `rackup` and `vegas`. The default path is '/'.
+
 Running with Docker
 ------------------------
 
@@ -131,7 +147,13 @@ ENV['BEANSTALKD_VIEW_TEMPLATES'] = File.join("my", "app", "views", "beanstalkd")
 
 Then just copy `lib/beanstalkd_view/views/*.erb` and customize them as you want.
 
-*Note: the environment variable should be set before gem loads.*
+If you run beanstalkd_view using the command line you can set the URL base path:
+
+```ruby
+ENV['BEANSTALKD_VIEW_PATH'] = '/path'
+```
+
+*Note: the environment variables should be set before gem loads.*
 
 License
 ------------------------

--- a/bin/beanstalkd_view
+++ b/bin/beanstalkd_view
@@ -10,5 +10,6 @@ end
 require 'beanstalkd_view'
 
 ENV['BEANSTALK_URL'] ||= 'beanstalk://localhost/'
+ENV['BEANSTALKD_VIEW_PATH'] ||= '/'
 
-Vegas::Runner.new(BeanstalkdView::Server, 'Beanstalkd View')
+Vegas::Runner.new(Rack::URLMap.new(ENV['BEANSTALKD_VIEW_PATH'] => BeanstalkdView::Server), 'Beanstalkd View')

--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,10 @@ $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/lib')
 ENV['BEANSTALK_URL'] ||= 'beanstalk://localhost/'
 #ENV['BEANSTALK_URL'] ||= 'beanstalk://localhost:11300,beanstalk://localhost:11400'
 
+ENV['BEANSTALKD_VIEW_PATH'] ||= '/'
+
 # config.ru
 require 'beanstalkd_view'
-run BeanstalkdView::Server
+run Rack::URLMap.new(
+  ENV['BEANSTALKD_VIEW_PATH'] => BeanstalkdView::Server
+)


### PR DESCRIPTION
Allow specifying the URL base when running standalone using the `BEANSTALKD_VIEW_PATH` environment variable (default: '/'). This applies to both `vegas` and `rackup`.

Really useful if you want to make the standalone app accessible from a different sub-uri. This is equivalent to the Rails `mount :at` option.