### PR TITLE
Change base docker image to ubuntu 14.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM debian:wheezy
+FROM ubuntu:14.04.3
 
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -y rubygems
+RUN apt-get install -y rubygems-integration ruby-dev make g++
 RUN gem install beanstalkd_view --no-rdoc --no-ri
+RUN gem install thin --no-rdoc --no-ri
 
 EXPOSE 5678
 


### PR DESCRIPTION
The resulting image when base is debian:wheezy fails (I believe the ruby version is too old) with:
/usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require': /var/lib/gems/1.8/gems/beaneater-1.0.0/lib/beaneater/connection.rb:176: syntax error, unexpected ':', expecting ')' (SyntaxError)
          transmit("watch #{t}", init: false)
                                      ^
/var/lib/gems/1.8/gems/beaneater-1.0.0/lib/beaneater/connection.rb:180: syntax error, unexpected ':', expecting ')'
...smit("use #{tube_used}", init: false) if @tube_used != 'defa...
                              ^
/var/lib/gems/1.8/gems/beaneater-1.0.0/lib/beaneater/connection.rb:242: syntax error, unexpected $end, expecting kEND
[...]
