### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1-slim
+FROM ruby:2.2-slim
 
 # thin requires some dev toll from build-essential
 RUN apt-get update && apt-get install -y build-essential \


### PR DESCRIPTION
Fix those errors (by updating ruby):

ERROR:  Error installing beanstalkd_view:
	rack requires Ruby version >= 2.2.2.
ERROR:  Error installing thin:
	rack requires Ruby version >= 2.2.2.